### PR TITLE
- Fix: Change expected `newVersion` on `blocked` event per spec

### DIFF
--- a/test/database.js
+++ b/test/database.js
@@ -255,7 +255,7 @@ QUnit.test("Block opening database with higher version.", function (assert) {
             request2.onblocked = function(args){
                 assert.equal("blocked", args.type, "blocked database");
                 assert.equal(args.oldVersion, version, "Old version");
-                assert.equal(args.newVersion, null, "New version");
+                assert.equal(args.newVersion, version+1, "New version");
                 e.target.result.close();
             };
             request2.onerror = function(){


### PR DESCRIPTION
http://w3c.github.io/IndexedDB/#opening

Relevant portions of spec:

> "If any of the connections in openConnections are still not closed, queue a task to fire a version change event named blocked at request with db’s version and version."

and

> To fire a version change event named e at target given oldVersion and newVersion, run the following steps:
> ...
> Set event’s newVersion attribute to newVersion.